### PR TITLE
Swerve command, PID tuning, and controller expo

### DIFF
--- a/simgui.json
+++ b/simgui.json
@@ -8,5 +8,12 @@
       "/LiveWindow/Ungrouped/PIDController[4]": "PIDController",
       "/LiveWindow/Ungrouped/Scheduler": "Scheduler"
     }
+  },
+  "NetworkTables": {
+    "transitory": {
+      "Devices": {
+        "open": true
+      }
+    }
   }
 }

--- a/src/main/java/frc/robot/Commands/DriveSwerveCommand.java
+++ b/src/main/java/frc/robot/Commands/DriveSwerveCommand.java
@@ -24,7 +24,6 @@ public class DriveSwerveCommand extends CommandBase {
         double ySpeed = m_controller.getLeftY();
         double rot = m_controller.getRightX();
         // m_swerveDrive.drive(0, 0.2, 0);
-
         // $TODO - Inverting y on joystick is a hack right now!
         m_swerveDrive.drive(xSpeed, -ySpeed, rot);
     }

--- a/src/main/java/frc/robot/Commands/DriveSwerveCommand.java
+++ b/src/main/java/frc/robot/Commands/DriveSwerveCommand.java
@@ -21,15 +21,15 @@ public class DriveSwerveCommand extends CommandBase {
     @Override
     public void execute() {
         if (m_controller.getLeftBumper()){
-            m_swerveDrive.resetGyroFieldRelative();
-            System.out.println("GYRO HOPEFULLY RESET");
+            m_swerveDrive.resetGyroFieldRelative(); //GYRO FIELD RELATIVE RESET in terms of the right side of the robot (radio side)
         } else {
             double xSpeed = m_controller.getLeftX();
             double ySpeed = m_controller.getLeftY();
             double rot = m_controller.getRightX();
-            // m_swerveDrive.drive(0, 0.2, 0);
+
+            m_swerveDrive.setFieldRelative(!m_controller.getRightBumper()); // Turns off field relative while pressed 
+            
             // $TODO - Inverting y on joystick is a hack right now!
-            m_swerveDrive.setFieldRelative(!m_controller.getRightBumper());
             m_swerveDrive.drive(xSpeed, -ySpeed, rot);
         }
         

--- a/src/main/java/frc/robot/Commands/DriveSwerveCommand.java
+++ b/src/main/java/frc/robot/Commands/DriveSwerveCommand.java
@@ -20,12 +20,20 @@ public class DriveSwerveCommand extends CommandBase {
 
     @Override
     public void execute() {
-        double xSpeed = m_controller.getLeftX();
-        double ySpeed = m_controller.getLeftY();
-        double rot = m_controller.getRightX();
-        // m_swerveDrive.drive(0, 0.2, 0);
-        // $TODO - Inverting y on joystick is a hack right now!
-        m_swerveDrive.drive(xSpeed, -ySpeed, rot);
+        if (m_controller.getLeftBumper()){
+            m_swerveDrive.resetGyroFieldRelative();
+            System.out.println("GYRO HOPEFULLY RESET");
+        } else {
+            double xSpeed = m_controller.getLeftX();
+            double ySpeed = m_controller.getLeftY();
+            double rot = m_controller.getRightX();
+            // m_swerveDrive.drive(0, 0.2, 0);
+            // $TODO - Inverting y on joystick is a hack right now!
+            m_swerveDrive.setFieldRelative(!m_controller.getRightBumper());
+            m_swerveDrive.drive(xSpeed, -ySpeed, rot);
+        }
+        
+        
     }
 
     @Override

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -4,8 +4,8 @@ public class Constants {
     public static class OperatorConstants {
         public static final int driveControllerPort = 0;
         public static final double controllerExpo = 4;
-        public static final double controllerExpoRatio = 0.4; // Change this variable if you want to change exponent
-        public static final double controllerDeadbandPercent = 0.07; // 0.2
+        public static final double controllerExpoRatio = 0.6; // Change this variable if you want to change exponent
+        public static final double controllerDeadbandPercent = 0.03; // 0.2
     }
 
     public static class SwerveSystemConstants {

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -3,7 +3,7 @@ package frc.robot;
 public class Constants {
     public static class OperatorConstants {
         public static final int driveControllerPort = 0;
-        public static final double controllerDeadbandPercent = 0.08;
+        public static final double controllerDeadbandPercent = 0.2;
     }
 
     public static class SwerveSystemConstants {
@@ -19,6 +19,7 @@ public class Constants {
         public static final double drivingPID_I = 0;
         public static final double drivingPID_D = 0;
 
+        // public static final double turningPID_P = 0.01;
         public static final double turningPID_P = 1;
         public static final double turningPID_I = 0;
         public static final double turningPID_D = 0.05;
@@ -28,8 +29,8 @@ public class Constants {
         public static final double drivingFeedForward_A = 0.1212;
 
         public static final double maxSpeedMetersPerSecond = 0.25; // $TODO - Normally, this was 2.0 but for now we want robot to crawlssss
-        public static final double maxAngularSpeed = 2.5;
-        public static final double maxAngularAcceleration = 2 * Math.PI;
+        public static final double maxAngularSpeed = 0.574*10; // 2.5
+        public static final double maxAngularAcceleration = 0.574*10; // 2 * Math.PI;
 
         public static final int swerveMotorCurrentLimit = 20;
 
@@ -56,10 +57,10 @@ public class Constants {
             public static final int backRightTurnEncoderChannel = 2;
             
             // Wheel should be facing inwards
-            public static final double frontLeftOffset = -Math.PI + .1;
-            public static final double backLeftOffset = 0.844 - 0.1 + Math.PI;
-            public static final double frontRightOffset = (Math.PI / 4) + ((Math.PI * 2) - 4.708) + 0.2;
-            public static final double backRightOffset =  0.628 + .3;
+            public static final double frontLeftOffset = -Math.PI + .1 + Math.PI/2;
+            public static final double backLeftOffset = 0.744 + Math.PI + Math.PI/2;
+            public static final double frontRightOffset = (Math.PI / 4) + ((Math.PI * 2) - 4.708) + 0.2 + Math.PI/2;
+            public static final double backRightOffset =  0.928 + Math.PI/2;
         }
     }
 }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -3,6 +3,8 @@ package frc.robot;
 public class Constants {
     public static class OperatorConstants {
         public static final int driveControllerPort = 0;
+        public static final double controllerExpo = 4;
+        public static final double controllerExpoRatio = 0.4; // Change this variable if you want to change exponent
         public static final double controllerDeadbandPercent = 0.07; // 0.2
     }
 
@@ -29,7 +31,7 @@ public class Constants {
         public static final double drivingFeedForward_V = 2.3901;
         public static final double drivingFeedForward_A = 0.1212;
 
-        public static final double maxSpeedMetersPerSecond = 4; // $TODO - Normally, this was 2.0 but for now we want robot to move slowly
+        public static final double maxSpeedMetersPerSecond = 2; // $TODO - Normally, this was 2.0 but for now we want robot to move slowly
         public static final double maxAngularSpeed = 0.574*100; // 2.5 (THESE VALUES ARE PRETTY RANDOM) was * 10
         public static final double maxAngularAcceleration = 0.574*100; // 2 * Math.PI; (THESE VALUES ARE PRETTY RANDOM)
 

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -3,7 +3,7 @@ package frc.robot;
 public class Constants {
     public static class OperatorConstants {
         public static final int driveControllerPort = 0;
-        public static final double controllerDeadbandPercent = 0.2;
+        public static final double controllerDeadbandPercent = 0.07; // 0.2
     }
 
     public static class SwerveSystemConstants {
@@ -15,22 +15,23 @@ public class Constants {
         public static final int gyroCanID = 7;
         public static final double maxOutputPercentage = 1;
 
-        public static final double drivingPID_P = 0.7;
+        // PID tunes for 51.5 pounds 
+        public static final double drivingPID_P = 3;
         public static final double drivingPID_I = 0;
-        public static final double drivingPID_D = 0;
+        public static final double drivingPID_D = 0.95;
 
-        // public static final double turningPID_P = 0.01;
-        public static final double turningPID_P = 1;
+       // PID tunes for 51.5 pounds 
+        public static final double turningPID_P = 2.45; 
         public static final double turningPID_I = 0;
-        public static final double turningPID_D = 0.05;
+        public static final double turningPID_D = 0.32;
 
         public static final double drivingFeedForward_S = 0.11095;
         public static final double drivingFeedForward_V = 2.3901;
         public static final double drivingFeedForward_A = 0.1212;
 
-        public static final double maxSpeedMetersPerSecond = .25; // $TODO - Normally, this was 2.0 but for now we want robot to move slowly
-        public static final double maxAngularSpeed = 0.574*10; // 2.5 (THESE VALUES ARE PRETTY RANDOM)
-        public static final double maxAngularAcceleration = 0.574*10; // 2 * Math.PI; (THESE VALUES ARE PRETTY RANDOM)
+        public static final double maxSpeedMetersPerSecond = 4; // $TODO - Normally, this was 2.0 but for now we want robot to move slowly
+        public static final double maxAngularSpeed = 0.574*100; // 2.5 (THESE VALUES ARE PRETTY RANDOM) was * 10
+        public static final double maxAngularAcceleration = 0.574*100; // 2 * Math.PI; (THESE VALUES ARE PRETTY RANDOM)
 
         public static final int swerveMotorCurrentLimit = 20;
 

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -28,9 +28,9 @@ public class Constants {
         public static final double drivingFeedForward_V = 2.3901;
         public static final double drivingFeedForward_A = 0.1212;
 
-        public static final double maxSpeedMetersPerSecond = 0.25; // $TODO - Normally, this was 2.0 but for now we want robot to crawlssss
-        public static final double maxAngularSpeed = 0.574*10; // 2.5
-        public static final double maxAngularAcceleration = 0.574*10; // 2 * Math.PI;
+        public static final double maxSpeedMetersPerSecond = .25; // $TODO - Normally, this was 2.0 but for now we want robot to move slowly
+        public static final double maxAngularSpeed = 0.574*10; // 2.5 (THESE VALUES ARE PRETTY RANDOM)
+        public static final double maxAngularAcceleration = 0.574*10; // 2 * Math.PI; (THESE VALUES ARE PRETTY RANDOM)
 
         public static final int swerveMotorCurrentLimit = 20;
 
@@ -56,11 +56,17 @@ public class Constants {
             public static final int backLeftTurnEncoderChannel = 1;
             public static final int backRightTurnEncoderChannel = 2;
             
-            // Wheel should be facing inwards
-            public static final double frontLeftOffset = -Math.PI + .1 + Math.PI/2;
-            public static final double backLeftOffset = 0.744 + Math.PI + Math.PI/2;
-            public static final double frontRightOffset = (Math.PI / 4) + ((Math.PI * 2) - 4.708) + 0.2 + Math.PI/2;
-            public static final double backRightOffset =  0.928 + Math.PI/2;
+            // Math.PI/2 offsets all wheels by 90 degrees which lets the rotation work. Before, the wheels were facing inwards which
+            //means when the robot tried to rotate, all the wheels were facing inwards which would cancel out the rotation.
+            // The wheels go from basically creating an X to creating an O because now all wheels are facing outwards when rotating
+            public static final double rotationOffset = Math.PI/2;
+            // NOTE: This makes the front of the robot the right side. (the side of the radio), but it does not neceassrily matter because
+            // of field relativity
+
+            public static final double frontLeftOffset = -Math.PI + .1 + rotationOffset;
+            public static final double backLeftOffset = 0.744 + Math.PI + rotationOffset;
+            public static final double frontRightOffset = (Math.PI / 4) + ((Math.PI * 2) - 4.708) + 0.2 + rotationOffset;
+            public static final double backRightOffset =  0.928 + rotationOffset;
         }
     }
 }

--- a/src/main/java/frc/robot/Subsystems/SwerveDriveSystem.java
+++ b/src/main/java/frc/robot/Subsystems/SwerveDriveSystem.java
@@ -120,11 +120,11 @@ public class SwerveDriveSystem extends SubsystemBase {
     displayModuleToSingleSwerveDashV2("Back Right", m_backRight);
 
     if (isPIDTuning) {
-      m_getPIDDriveP = Shuffleboard.getTab("Swerve Tuning").getLayout("PID Tuning Drive Values", BuiltInLayouts.kList).add("Drive P", SwerveModule.pidDriveP).withWidget(BuiltInWidgets.kNumberSlider).getEntry();
-      m_getPIDDriveD = Shuffleboard.getTab("Swerve Tuning").getLayout("PID Tuning Drive Values", BuiltInLayouts.kList).add("Drive D", SwerveModule.pidDriveD).withWidget(BuiltInWidgets.kNumberSlider).getEntry();
+      m_getPIDDriveP = Shuffleboard.getTab("Swerve Tuning").getLayout("PID Tuning Drive Values", BuiltInLayouts.kList).add("Drive P", SwerveModule.pidDriveP).withWidget(BuiltInWidgets.kNumberSlider).withProperties(Map.of("min", 0, "max", 5)).getEntry();
+      m_getPIDDriveD = Shuffleboard.getTab("Swerve Tuning").getLayout("PID Tuning Drive Values", BuiltInLayouts.kList).add("Drive D", SwerveModule.pidDriveD).withWidget(BuiltInWidgets.kNumberSlider).withProperties(Map.of("min", 0, "max", 5)).getEntry();
 
-      m_getPIDTurnP = Shuffleboard.getTab("Swerve Tuning").getLayout("PID Tuning Turn Values", BuiltInLayouts.kList).add("Turn P", SwerveModule.pidTurnP).withWidget(BuiltInWidgets.kNumberSlider).getEntry();
-      m_getPIDTurnD = Shuffleboard.getTab("Swerve Tuning").getLayout("PID Tuning Turn Values", BuiltInLayouts.kList).add("Turn D", SwerveModule.pidTurnD).withWidget(BuiltInWidgets.kNumberSlider).getEntry();
+      m_getPIDTurnP = Shuffleboard.getTab("Swerve Tuning").getLayout("PID Tuning Turn Values", BuiltInLayouts.kList).add("Turn P", SwerveModule.pidTurnP).withWidget(BuiltInWidgets.kNumberSlider).withProperties(Map.of("min", 0, "max", 5)).getEntry();
+      m_getPIDTurnD = Shuffleboard.getTab("Swerve Tuning").getLayout("PID Tuning Turn Values", BuiltInLayouts.kList).add("Turn D", SwerveModule.pidTurnD).withWidget(BuiltInWidgets.kNumberSlider).withProperties(Map.of("min", 0, "max", 5)).getEntry();
     }
   }
 

--- a/src/main/java/frc/robot/Subsystems/SwerveDriveSystem.java
+++ b/src/main/java/frc/robot/Subsystems/SwerveDriveSystem.java
@@ -129,9 +129,9 @@ public class SwerveDriveSystem extends SubsystemBase {
   }
 
   public void setFieldRelative(boolean fieldRelative){
-    m_fieldRelative = fieldRelative;
+    m_fieldRelative = fieldRelative; // Sets field relative to true or false dependent on right bumper being pressed
   }
-  
+
   public void drive(double xSpeed, double ySpeed, double rot) {
     drive(xSpeed, ySpeed, rot, m_fieldRelative); 
   }

--- a/src/main/java/frc/robot/Subsystems/SwerveDriveSystem.java
+++ b/src/main/java/frc/robot/Subsystems/SwerveDriveSystem.java
@@ -7,6 +7,7 @@ package frc.robot.Subsystems;
 import java.util.Map;
 import java.util.function.DoubleSupplier;
 
+import com.ctre.phoenix.ErrorCode;
 import com.ctre.phoenix.sensors.Pigeon2;
 
 import edu.wpi.first.math.geometry.Rotation2d;
@@ -39,6 +40,7 @@ public class SwerveDriveSystem extends SubsystemBase {
 
   private final double maxSpeed = SwerveSystemConstants.maxSpeedMetersPerSecond;
   private final double maxAngularSpeed = SwerveSystemConstants.maxAngularSpeed;
+  private boolean m_fieldRelative = true;
 
   private final Translation2d m_frontLeftLocation = new Translation2d(SwerveSystemConstants.frameDistanceToModulesMeters, SwerveSystemConstants.frameDistanceToModulesMeters);
   private final Translation2d m_frontRightLocation = new Translation2d(SwerveSystemConstants.frameDistanceToModulesMeters, -SwerveSystemConstants.frameDistanceToModulesMeters);
@@ -126,8 +128,12 @@ public class SwerveDriveSystem extends SubsystemBase {
     }
   }
 
+  public void setFieldRelative(boolean fieldRelative){
+    m_fieldRelative = fieldRelative;
+  }
+  
   public void drive(double xSpeed, double ySpeed, double rot) {
-    drive(xSpeed, ySpeed, rot, true); 
+    drive(xSpeed, ySpeed, rot, m_fieldRelative); 
   }
 
   public void drive(double xSpeed, double ySpeed, double rot, boolean fieldRelative) {
@@ -227,7 +233,11 @@ public class SwerveDriveSystem extends SubsystemBase {
     return m_odometry.getPoseMeters().getX();
   }
 
-  
+  public boolean resetGyroFieldRelative(){
+    return ErrorCode.OK == m_gyro.setYaw(0.0);
+  }
+
+
   public double getAnglePosition() {
     return m_gyro.getYaw(); // rotation in horizontal plane
   }

--- a/src/main/java/frc/robot/Subsystems/SwerveDriveSystem.java
+++ b/src/main/java/frc/robot/Subsystems/SwerveDriveSystem.java
@@ -80,6 +80,7 @@ public class SwerveDriveSystem extends SubsystemBase {
             m_frontLeftLocation, m_frontRightLocation, m_backLeftLocation, m_backRightLocation
         );
 
+
   private final SwerveDriveOdometry m_odometry =
       new SwerveDriveOdometry(
           m_kinematics,
@@ -91,6 +92,8 @@ public class SwerveDriveSystem extends SubsystemBase {
           m_backRight.getPosition()
       });
 
+
+
   public SwerveDriveSystem(AppliedController controller) {
     initShuffleBoard();
     setDefaultCommand(
@@ -99,10 +102,14 @@ public class SwerveDriveSystem extends SubsystemBase {
   }
 
   public void initShuffleBoard() {
+
+
+
     m_frontLeft.displayDesiredStateToDashBoard("Front Left");
     m_backLeft.displayDesiredStateToDashBoard("Back Left");
     m_frontRight.displayDesiredStateToDashBoard("Front Right");
     m_backRight.displayDesiredStateToDashBoard("Back Right");
+
 
     // Also display all Swerve values on a SINGLE dashboard using a Grid layout
     displayModuleToSingleSwerveDashV2("Front Left", m_frontLeft);
@@ -120,7 +127,7 @@ public class SwerveDriveSystem extends SubsystemBase {
   }
 
   public void drive(double xSpeed, double ySpeed, double rot) {
-    drive(xSpeed, ySpeed, rot, false);
+    drive(xSpeed, ySpeed, rot, true); 
   }
 
   public void drive(double xSpeed, double ySpeed, double rot, boolean fieldRelative) {
@@ -131,6 +138,7 @@ public class SwerveDriveSystem extends SubsystemBase {
             fieldRelative
                 ? ChassisSpeeds.fromFieldRelativeSpeeds(xSpeed, ySpeed, rot * maxAngularSpeed, makeRotation2d())
                 : new ChassisSpeeds(xSpeed, ySpeed, rot * maxAngularSpeed));
+    
     SwerveDriveKinematics.desaturateWheelSpeeds(swerveModuleStates, maxSpeed);
     m_frontLeft.setDesiredState(swerveModuleStates[0]);
     m_frontRight.setDesiredState(swerveModuleStates[1]);
@@ -219,12 +227,13 @@ public class SwerveDriveSystem extends SubsystemBase {
     return m_odometry.getPoseMeters().getX();
   }
 
+  
   public double getAnglePosition() {
-    return m_gyro.getRoll();
+    return m_gyro.getYaw(); // rotation in horizontal plane
   }
 
   public Rotation2d makeRotation2d() {
-    return Rotation2d.fromRotations(getAnglePosition());
+    return Rotation2d.fromDegrees(getAnglePosition()); // converts from degrees 
   }
 
   public void updatePIDFromShuffleBoard() {

--- a/src/main/java/frc/robot/Util/AppliedController.java
+++ b/src/main/java/frc/robot/Util/AppliedController.java
@@ -6,30 +6,37 @@ import frc.robot.Constants.OperatorConstants;
 
 public class AppliedController extends XboxController {
     private double controllerDeadband;
+    private double controllerExponent;
 
     public AppliedController(int port) {
         super(port);
         this.controllerDeadband = OperatorConstants.controllerDeadbandPercent;
+        this.controllerExponent = Math.pow(OperatorConstants.controllerExpo, OperatorConstants.controllerExpoRatio);
+    }
+
+    public double expo(double input){
+        double expo = Math.pow(Math.abs(input), controllerExponent);
+        return input < 0 ? -expo : expo;
     }
 
     @Override
     public double getLeftY() {
-        return MathUtil.applyDeadband(super.getLeftY(), controllerDeadband);
+        return MathUtil.applyDeadband(expo(super.getLeftY()), controllerDeadband);
     }
 
     @Override
     public double getRightY() {
-        return MathUtil.applyDeadband(super.getRightY(), controllerDeadband);
+        return MathUtil.applyDeadband(expo(super.getRightY()), controllerDeadband);
     }
 
     @Override
     public double getLeftX() {
-        return MathUtil.applyDeadband(super.getLeftX(), controllerDeadband);
+        return MathUtil.applyDeadband(expo(super.getLeftX()), controllerDeadband);
     }
 
     @Override
     public double getRightX() {
-        return MathUtil.applyDeadband(super.getRightX(), controllerDeadband);
+        return MathUtil.applyDeadband(expo(super.getRightX()), controllerDeadband);
     }
 
     public boolean commandCancel() {


### PR DESCRIPTION
This fixes bugs with Swerve to make it work; reset field relative with left bumper, hold right bumper to disable field relative; PID is tuned for the robot at 51lbs weight; added exponential curve to joystick input and reduced deadband.